### PR TITLE
Correção número negativo

### DIFF
--- a/src/rush/recursos/gerais/BloquearMoneyInvalido.java
+++ b/src/rush/recursos/gerais/BloquearMoneyInvalido.java
@@ -12,7 +12,7 @@ public class BloquearMoneyInvalido implements Listener {
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void aoTentarVender(PlayerCommandPreprocessEvent e) {
-		if (e.getMessage().contains("mercado vender -") || e.getMessage().contains("market vender -")) {
+		if (e.getMessage().toLowerCase().contains("mercado vender -") || e.getMessage().toLowerCase().contains("market vender -")) {
 			e.getPlayer().sendMessage(Mensagens.Numero_Invalido.replace("%numero%", "-"));
 			e.setCancelled(true);
 		}


### PR DESCRIPTION
Corrige falha que permite usar números negativos.
Exemplo da falha:
/mercado VENDER -9999999