### PR TITLE
Corrigir ArrayIndexOutOfBoundException

### DIFF
--- a/src/rush/sistemas/gerais/DeletarComandos.java
+++ b/src/rush/sistemas/gerais/DeletarComandos.java
@@ -49,7 +49,7 @@ public class DeletarComandos {
 						
 						else if (plugin.equals("*")) {
 							for (Entry<String, Command> entry : commands.entrySet()) {
-								if (entry.getValue().getName().toLowerCase().equals(command) || (entry.getKey().contains(":") && entry.getKey().toLowerCase().split(":")[1].equals(command))) {
+								if (entry.getValue().getName().toLowerCase().equals(command) || (entry.getKey().split(":").length > 1 && entry.getKey().toLowerCase().split(":")[1].equals(command))) {
 									removes.add(entry);
 								}
 							}
@@ -57,7 +57,7 @@ public class DeletarComandos {
 						
 						else {
 							for (Entry<String, Command> entry : commands.entrySet()) {
-								if (entry.getKey().contains(":") && entry.getKey().toLowerCase().split(":")[0].equals(plugin) && (entry.getValue().getName().toLowerCase().equals(command) || entry.getKey().toLowerCase().split(":")[1].equals(command) )) {
+								if (entry.getKey().split(":").length > 1 && entry.getKey().toLowerCase().split(":")[0].equals(plugin) && (entry.getValue().getName().toLowerCase().equals(command) || entry.getKey().toLowerCase().split(":")[1].equals(command) )) {
 									removes.add(entry);
 								}
 							}


### PR DESCRIPTION
Sei que o código atual checa se contém ":" antes de dividir a String, mas se for uma String como "aaaa:", vai ser de tamanho 1, pois a parte dois estaria em branco. (Isso está na documentação do método String#split()).
```
11.11 22:31:45 [Server] WARN java.lang.ArrayIndexOutOfBoundsException: 1
11.11 22:31:45 [Server] WARN at rush.sistemas.gerais.DeletarComandos$1.run(DeletarComandos.java:52)
11.11 22:31:45 [Server] WARN at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftTask.run(CraftTask.java:59)
11.11 22:31:45 [Server] WARN at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:53)
11.11 22:31:45 [Server] WARN at org.github.paperspigot.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:23)
11.11 22:31:45 [Server] WARN at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
11.11 22:31:45 [Server] WARN at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
11.11 22:31:45 [Server] WARN at java.lang.Thread.run(Thread.java:748)
```