### PR TITLE
Update Kits.java

### DIFF
--- a/src/rush/entidades/Kits.java
+++ b/src/rush/entidades/Kits.java
@@ -39,18 +39,19 @@ public abstract class Kits {
 		
 		File folder = DataManager.getFolder("kits");
 		File[] file = folder.listFiles();
-		
-		for (int i = 0; i < file.length; i++) {
-			if (file[i].isFile()) {
+		if(file != null) {
+			for (int i = 0; i < file.length; i++) {
+				if (file[i] != null && file[i].isFile())  {
 				FileConfiguration configKit = DataManager.getConfiguration(file[i]);
 				String id = file[i].getName().replace(".yml", "");
-				String nome = configKit.getString("Nome", "§rKit '" + id + "' sem nome! Use /editarkit!");
+				String nome = configKit.getString("Nome", "Â§rKit '" + id + "' sem nome! Use /editarkit!");
 				String permissao = configKit.getString("Permissao", "");
 				long delay = configKit.getLong("Delay");
 				String mensagemDeErro = configKit.getString("MensagemDeErro", "");
 				String itens = configKit.getString("Itens");
 				Kit kit = new Kit(id, permissao, nome, delay, mensagemDeErro, itens);
 				KITS.put(id, kit);
+				}
 			}
 		}	
 	}


### PR DESCRIPTION
o objeto folder não é um diretório (ou não existe) e o listFiles() retornou null, fazendo com que File[] file = null.
Daí ao tentar acessar o tamanho da lista de files file.length resultou em null.length, o que lança a exceção de NullPointerException. 
Basicamente ele faz que o "for (int i = 0; i < file.length; i++) {" tonar um file.lenght que ira resultar em null.lenght que vai lançar uma exceção de NullPointerException.