### PR TITLE
Update Warps.java

### DIFF
--- a/src/rush/entidades/Warps.java
+++ b/src/rush/entidades/Warps.java
@@ -36,12 +36,11 @@ public abstract class Warps {
 	
 	public static void loadWarps() {
 		WARPS.clear();
-		
 		File folder = DataManager.getFolder("warps");
 		File[] file = folder.listFiles();
-		
-		for (int i = 0; i < file.length; i++) {
-			if (file[i].isFile()) {
+		if(file != null) {
+			for (int i = 0; i < file.length; i++) {
+				if (file[i] != null && file[i].isFile())  {
 				FileConfiguration configWarp = DataManager.getConfiguration(file[i]);
 				String nome = file[i].getName().replace(".yml", "");
 				String loc = configWarp.getString("Localizacao");
@@ -59,6 +58,7 @@ public abstract class Warps {
 				String teleportadoStaff = configWarp.getString("MensagemPlayerTeleportadoStaff", "");
 				Warp warp = new Warp(nome, loc, perm, semPerm, delay, delayVip, mensagem, inicio, fim, enviar, title, subTitle, teleportado, teleportadoStaff);
 				WARPS.put(nome, warp);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
o objeto folder não é um diretório (ou não existe) e o listFiles() retornou null, fazendo com que File[] file = null.
Daí ao tentar acessar o tamanho da lista de files file.length resultou em null.length, o que lança a exceção de NullPointerException. 
Basicamente ele faz que o "for (int i = 0; i < file.length; i++) {" tonar um file.lenght que ira resultar em null.lenght que vai lançar uma exceção de NullPointerException.